### PR TITLE
[SECTION-031] ユーザーページの実装

### DIFF
--- a/app/pages/users/_id.vue
+++ b/app/pages/users/_id.vue
@@ -1,0 +1,73 @@
+<template>
+  <div>
+    <el-row v-if="user">
+      <el-col :span="6">
+        <el-card class="text-center" style="margin-right: 16px;">
+          <div>
+            <img src="https://placehold.it/150x150"
+                 style="width: 100%;margin-bottom: 16px;border-radius: 2px;"
+                 alt=""
+            />
+          </div>
+          <h2>
+            <b>
+              {{user.id}}
+            </b>
+          </h2>
+        </el-card>
+      </el-col>
+      <el-col :span="18">
+        <el-card>
+          <div slot="header" class="clearfix">
+            <span>{{user.id}} さんの投稿</span>
+          </div>
+          <el-table
+            :data="userPosts"
+            style="width: 100%"
+            class="table"
+          >
+            <el-table-column
+              prop="title"
+              label="タイトル"
+            />
+            <el-table-column
+              prop="created_at"
+              label="投稿日時"
+              width="160"
+            />
+          </el-table>
+        </el-card>
+      </el-col>
+    </el-row>
+  </div>
+</template>
+
+<script>
+import moment from '~/plugins/moment'
+import {mapGetters} from 'vuex'
+
+export default {
+  async asyncData({store, route, error}) {
+    const {id} = route.params
+    try {
+      await store.dispatch('users/fetchUser', {id})
+    } catch (e) {
+      error({statusCode: 404})
+    }
+  },
+  computed: {
+    userPosts(){
+      return Object.entries(this.user.posts).map(([id,post]) => {
+        post.created_at = moment(post.created_at).format('YYYY/MM/DD HH:mm:ss')
+        return {id, ...post}
+      })
+    },
+    user(){
+      const user = this.users.find(u => u.id === this.$route.params.id)
+      if(!user) return null
+      return Object.assign({posts: []}, user)
+    },
+    ...mapGetters('users',['users'])
+  }
+}
+</script>

--- a/app/pages/users/_id.vue
+++ b/app/pages/users/_id.vue
@@ -24,6 +24,7 @@
           <el-table
             :data="userPosts"
             style="width: 100%"
+            @row-click="handleClick"
             class="table"
           >
             <el-table-column
@@ -48,6 +49,7 @@ import {mapGetters} from 'vuex'
 
 export default {
   async asyncData({store, route, error}) {
+    await store.dispatch('posts/fetchPosts')
     const {id} = route.params
     try {
       await store.dispatch('users/fetchUser', {id})
@@ -68,6 +70,11 @@ export default {
       return Object.assign({posts: []}, user)
     },
     ...mapGetters('users',['users'])
+  },
+  methods: {
+    handleClick(post){
+      this.$router.push(`/posts/${post.id}`)
+    }
   }
 }
 </script>

--- a/app/store/posts.js
+++ b/app/store/posts.js
@@ -21,14 +21,14 @@ export const mutations = {
 }
 
 export const actions = {
-  async fetchPost({commit}, {id}){
+  async fetchPost({commit}, {id}) {
     const post = await this.$axios.$get(`/posts/${id}.json`)
-    commit('addPost', { post: { ...post, id } })
+    commit('addPost', {post: {...post, id}})
   },
   async fetchPosts({commit}) {
     const posts = await this.$axios.$get(`/posts.json`)
     commit('clearPosts')
-    Object.entries(posts)
+    Object.entries(posts || [])
       .reverse()
       .forEach(([id, content]) =>
         commit('addPost', {

--- a/app/store/users.js
+++ b/app/store/users.js
@@ -1,0 +1,26 @@
+export const state = () => ({
+  users: []
+})
+
+export const getters = {
+  users: (state) => state.users
+}
+
+export const mutations = {
+  addUser(state, {user}) {
+    state.users.push(user)
+  },
+  addUserPost(state, {user, post}) {
+    state.userPosts[user.id].push(post)
+  },
+  clearUserPosts(state, {user}) {
+    state.userPosts[user.id] = []
+  }
+}
+
+export const actions = {
+  async fetchUser({commit}, {id}) {
+    const user = await this.$axios.$get(`/users/${id}.json`)
+    commit('addUser', {user})
+  }
+}


### PR DESCRIPTION
ビギナー本SECTION-031完了。

### 変更点

- ユーザー個別ページ作成（マイページ）
- ユーザー個別ページに、ユーザーが作成した記事一覧を表示
- 記事一覧から個別記事へリンク追加

### 変更後画面キャプチャ

![nuxt-blog-service1](https://user-images.githubusercontent.com/10894015/61645159-06032800-ace1-11e9-840f-1965d9048bee.png)

### 学んだことなど

- ユーザー個別ページは、記事個別ページと似たような要領で実装できたので、目新しいことはなかった印象

- ユーザー個別ページに表示させる記事一覧から、記事個別ページへのリンクは、ビギナー本では実装されてなかったけど、他のコードを参考に実装してみた。チュートリアル通りに実装するんじゃなくて、一手間加えるとより理解が深まりそうでよかった


### わからなかったこと（あとで調べる）

`return Object.entries(this.user.posts).map(([id,post]) ` この辺りのコードに出てくる `Object` の意味について、まだちゃんと把握できていないので調べる